### PR TITLE
Return error if multiple implementations are present for one interface

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -180,10 +180,8 @@ func (i *injector) Get(t reflect.Type) reflect.Value {
 			}
 		}
 	}
-	if len(impls) > 1 {
-		if i.options.PanicOnAmbiguity {
-			panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
-		}
+	if len(impls) > 1 && i.options.PanicOnAmbiguity {
+		panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
 	}
 	if len(impls) > 0 {
 		val = impls[0]

--- a/inject.go
+++ b/inject.go
@@ -56,6 +56,8 @@ type TypeMapper interface {
 
 // InjectorOptions contains options to configure the injector
 type InjectorOptions struct {
+	// If PanicOnAmbiguity is set to true, Get method will panic if it finds multiple
+	// implementations that satisfy the given type.
 	PanicOnAmbiguity bool
 }
 

--- a/inject_test.go
+++ b/inject_test.go
@@ -11,7 +11,7 @@ type SpecialString interface {
 
 type TestStruct struct {
 	Dep1 string        `inject:"t" json:"-"`
-	Dep2 SpecialString `inject:"t"`
+	Dep2 SpecialString `inject`
 	Dep3 string
 }
 
@@ -185,5 +185,5 @@ func TestInjectImplementors_AmbiguousImplementationPanic(t *testing.T) {
 	})
 	g1, g2 := &Greeter{"Jeremy"}, &Greeter2{"Tom"}
 	injector.Map(g1).Map(g2)
-	expect(t, injector.Get(InterfaceOf((*fmt.Stringer)(nil))).IsValid(), true)
+	injector.Get(InterfaceOf((*fmt.Stringer)(nil)))
 }


### PR DESCRIPTION
Currently, if there are multiple implementations that satisfy the same interface, `Get` method will silently pick the first implementation without warning the users. This could be dangerous. In this PR, we're going to modify the `Get` method to allow it to return an error if that happens. 