### PR TITLE
Print out more info

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -183,7 +183,7 @@ func (i *injector) Get(t reflect.Type) reflect.Value {
 		}
 	}
 	if len(impls) > 1 && i.options.PanicOnAmbiguity {
-		panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
+		panic(fmt.Sprintf("Expected single matching implementation for type %v but found %v: %v", t, len(impls), impls))
 	}
 	if len(impls) > 0 {
 		val = impls[0]

--- a/inject.go
+++ b/inject.go
@@ -183,7 +183,7 @@ func (i *injector) Get(t reflect.Type) reflect.Value {
 		}
 	}
 	if len(impls) > 1 && i.options.PanicOnAmbiguity {
-		panic(fmt.Sprintf("Expected single matching implementation for type %v but found %v: %v", t, len(impls), impls))
+		panic(fmt.Sprintf("Expected single matching implementation for type <%v> but found %v: %v", t, len(impls), impls))
 	}
 	if len(impls) > 0 {
 		val = impls[0]

--- a/inject_test.go
+++ b/inject_test.go
@@ -176,7 +176,7 @@ func TestInjectImplementors_AmbiguousImplementation(t *testing.T) {
 func TestInjectImplementors_AmbiguousImplementationPanic(t *testing.T) {
 	defer func() {
 		r := recover()
-		expect(t, r, "Expect single matching implementation but found 2")
+		expect(t, r, "Expected single matching implementation for type fmt.Stringer but found 2: [<*inject.Greeter Value> <*inject.Greeter2 Value>]")
 	}()
 
 	injector := New()

--- a/inject_test.go
+++ b/inject_test.go
@@ -176,7 +176,7 @@ func TestInjectImplementors_AmbiguousImplementation(t *testing.T) {
 func TestInjectImplementors_AmbiguousImplementationPanic(t *testing.T) {
 	defer func() {
 		r := recover()
-		expect(t, r, "Expected single matching implementation for type fmt.Stringer but found 2: [<*inject.Greeter Value> <*inject.Greeter2 Value>]")
+		expect(t, r, "Expected single matching implementation for type <fmt.Stringer> but found 2: [<*inject.Greeter Value> <*inject.Greeter2 Value>]")
 	}()
 
 	injector := New()


### PR DESCRIPTION
Print out the name of the requested type, and the ambiguous implementations when panicking. This will be helpful for debugging. 